### PR TITLE
ci: run Lefthook checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,19 +43,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint commits
+      - name: Run Lefthook file checks
+        run: pnpm lefthook run pre-commit --all-files --force --fail-on-changes
+
+      - name: Run Lefthook commit checks
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          commits="$RUNNER_TEMP/commits"
+          message="$RUNNER_TEMP/commit-message"
+
           if git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            pnpm exec commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
+            git rev-list --reverse "$BASE_SHA..$HEAD_SHA" > "$commits"
           else
-            pnpm exec commitlint --last --verbose
+            echo "$HEAD_SHA" > "$commits"
           fi
 
-      - name: Lint
+          while IFS= read -r commit; do
+            git show --no-patch --format=%B "$commit" > "$message"
+            pnpm lefthook run commit-msg "$message" --force
+          done < "$commits"
+
+      - name: Run Bazel package checks
         run: bazel test //:lint
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           done < "$commits"
 
       - name: Run Bazel package checks
-        run: bazel test //:lint
+        run: bazel test //:package_checks
 
   build:
     timeout-minutes: 5

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,14 +4,14 @@ load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@npm//:@arethetypeswrong/cli/package_json.bzl", attw_bin = "bin")
 load("@npm//:mocha/package_json.bzl", mocha_bin = "bin")
-load("@npm//:oxfmt/package_json.bzl", oxfmt_bin = "bin")
-load("@npm//:oxlint/package_json.bzl", oxlint_bin = "bin")
 load("@npm//:publint/package_json.bzl", publint_bin = "bin")
 load("@npm//:typescript/package_json.bzl", typescript_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:tsconfig.bzl", "BASE_COMPILER_OPTIONS", "TSCONFIG")
 
 package(default_visibility = ["//visibility:public"])
+
+exports_files(["package.json"])
 
 npm_link_all_packages()
 
@@ -123,52 +123,6 @@ mocha_bin.mocha_test(
     ],
 )
 
-FORMAT_SOURCES = glob(
-    [
-        ".github/**/*.yaml",
-        ".github/**/*.yml",
-        "src/**/*.ts",
-        "tests/**/*.ts",
-        "*.json",
-        "*.md",
-        "*.mjs",
-        "*.yml",
-    ],
-    allow_empty = True,
-    exclude = ["src/generated/**"],
-)
-
-LINT_SOURCES = glob(
-    [
-        "src/**/*.ts",
-        "tests/**/*.ts",
-    ],
-    exclude = ["src/generated/**"],
-)
-
-oxfmt_bin.oxfmt_test(
-    name = "format_check",
-    args = [
-        "--check",
-        "--config=$(rootpath :.oxfmtrc.json)",
-        "--ignore-path=$(rootpath :.prettierignore)",
-    ] + FORMAT_SOURCES,
-    data = [
-        ".oxfmtrc.json",
-        ".prettierignore",
-    ] + FORMAT_SOURCES,
-)
-
-oxlint_bin.oxlint_test(
-    name = "oxlint",
-    args = [
-        "--config=$(rootpath :.oxlintrc.json)",
-    ] + LINT_SOURCES,
-    data = [
-        ".oxlintrc.json",
-    ] + LINT_SOURCES,
-)
-
 publint_bin.publint_test(
     name = "publint",
     args = [
@@ -192,11 +146,9 @@ attw_bin.attw_test(
 )
 
 test_suite(
-    name = "lint",
+    name = "package_checks",
     tests = [
         ":attw",
-        ":format_check",
-        ":oxlint",
         ":publint",
         ":tsconfig_tests",
     ],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "bazel build //:pkg",
     "format": "lefthook run pre-commit --all-files",
     "prepare": "lefthook install",
-    "lint": "bazel test //:lint",
+    "lint": "lefthook run pre-commit --all-files --force --fail-on-changes",
     "fix": "pnpm format"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- run Oxfmt and Oxlint only through Lefthook
- validate each pushed commit through the Lefthook commit-msg hook
- remove Bazel formatter/linter wrappers
- keep Publint, ATTW, and tsconfig validation under `//:package_checks`

## Test

- `npm run lint`
- `lefthook run commit-msg .git/COMMIT_EDITMSG --force`
- `bazel test //...`