### PR TITLE
fix(ci): allow Release Please commits

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,3 +1,23 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'release',
+        'revert',
+        'style',
+        'test',
+      ],
+    ],
+  },
 };


### PR DESCRIPTION
## Summary

- allow the `release` Conventional Commit type
- unblock Release Please generated commits such as `release: 0.38.0`

## Root cause

Commitlint default type list rejected Release Please release commits.

## Test

- `printf "release: 0.38.0\n" | commitlint --verbose`
- Lefthook pre-commit checks