### PR TITLE
ci: check Gazelle in Lefthook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-lint
+          repository-cache: true
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,6 +11,8 @@ commit-msg:
 
 pre-commit:
   commands:
+    gazelle:
+      run: bazel run //:gazelle -- -mode=diff
     oxlint:
       glob: '*.{cjs,js,mjs,ts,tsx}'
       run: ./node_modules/.bin/oxlint --fix {staged_files}


### PR DESCRIPTION
## Summary

- run Gazelle in diff mode during Lefthook pre-commit checks
- fail local commits and CI when generated BUILD files are stale
- set up cached Bazel tooling in the CI lint job

## Test

- `node_modules/.bin/lefthook run pre-commit --all-files --force --fail-on-changes`
