### PR TITLE
test: add published SDK parity E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+name: SDK E2E
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-e2e
+          repository-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '26'
+
+      - name: Enable pnpm
+        run: corepack enable pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Compare candidate with published SDK
+        run: bazel test //e2e:sdk_parity

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,0 +1,50 @@
+name: Functional tests
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: functional-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  functional-tests:
+    if: github.ref == 'refs/heads/main'
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-functional-tests
+          repository-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '26'
+
+      - name: Enable pnpm
+        run: corepack enable pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Refresh published SDK
+        run: pnpm update published-sdk --latest
+
+      - name: Run functional tests
+        env:
+          PPLX_API_TOKEN: ${{ secrets.PPLX_API_TOKEN }}
+        run: bazel test //e2e:live --test_env=PPLX_API_TOKEN

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -1,0 +1,66 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("//:ts.bzl", "ts_library")
+load("//:tsconfig.bzl", "BASE_COMPILER_OPTIONS")
+
+package(default_visibility = ["//visibility:private"])
+
+js_test(
+    name = "sdk_parity",
+    data = [
+        ":typecheck",
+        "//:node_modules/@perplexity-ai/perplexity_ai",
+        "//:node_modules/published-sdk",
+    ],
+    entry_point = "sdk-parity.ts",
+    tags = ["manual"],
+)
+
+js_test(
+    name = "live",
+    data = [
+        ":typecheck",
+        "//:node_modules/@perplexity-ai/perplexity_ai",
+        "//:node_modules/published-sdk",
+    ],
+    entry_point = "live.ts",
+    tags = ["manual"],
+)
+
+ts_project(
+    name = "typecheck",
+    srcs = [
+        "live.ts",
+        "sdk-parity.ts",
+    ],
+    no_emit = True,
+    tags = ["manual"],
+    tsc = "//:tsc",
+    tsconfig = {
+        "compilerOptions": dict(
+            BASE_COMPILER_OPTIONS,
+            module = "ESNext",
+            moduleResolution = "Bundler",
+            types = ["node"],
+        ),
+    },
+    deps = [
+        "//:node_modules/@perplexity-ai/perplexity_ai",
+        "//:node_modules/@types/node",
+        "//:node_modules/published-sdk",
+    ],
+)
+
+ts_library(
+    name = "e2e",
+    srcs = [
+        "live.ts",
+        "sdk-parity.ts",
+    ],
+    tsconfig_types = ["node"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:node_modules/@types/node",
+        "//:node_modules/published-sdk",
+    ],
+)

--- a/e2e/live.ts
+++ b/e2e/live.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+// oxlint-disable-next-line no-restricted-imports -- Verify packaged public entrypoint.
+import { Perplexity as Candidate } from '@perplexity-ai/perplexity_ai';
+import { Perplexity as Published } from 'published-sdk';
+
+interface CompletionResponse {
+  choices: Array<{
+    index: number;
+    message: {
+      content: string;
+      role: string;
+    };
+    [key: string]: unknown;
+  }>;
+  id: string;
+  model: string;
+  [key: string]: unknown;
+}
+
+function completionContract(response: unknown) {
+  assert.ok(typeof response === 'object' && response !== null);
+  const completion = response as CompletionResponse;
+
+  assert.equal(typeof completion.id, 'string');
+  assert.equal(typeof completion.model, 'string');
+  assert.ok(Array.isArray(completion.choices));
+  assert.ok(completion.choices.length > 0);
+
+  const choice = completion.choices[0];
+  assert.ok(choice);
+  assert.equal(typeof choice.index, 'number');
+  assert.equal(typeof choice.message?.content, 'string');
+  assert.equal(choice.message?.role, 'assistant');
+
+  return {
+    choiceKeys: Object.keys(choice).sort(),
+    messageKeys: Object.keys(choice.message).sort(),
+    responseKeys: Object.keys(completion).sort(),
+  };
+}
+
+const request = {
+  max_tokens: 16,
+  messages: [{ content: 'Reply with only the word pong.', role: 'user' as const }],
+  model: 'sonar',
+  temperature: 0,
+};
+
+describe('live API parity', () => {
+  it('matches published chat completion response contract', async () => {
+    const apiKey = process.env['PPLX_API_TOKEN'];
+    assert.ok(apiKey, 'PPLX_API_TOKEN must be set');
+
+    const [candidateResponse, publishedResponse] = await Promise.all([
+      new Candidate({ apiKey, maxRetries: 0 }).chat.completions.create(request),
+      new Published({ apiKey, maxRetries: 0 }).chat.completions.create(request),
+    ]);
+
+    assert.deepStrictEqual(completionContract(candidateResponse), completionContract(publishedResponse));
+  });
+});

--- a/e2e/sdk-parity.ts
+++ b/e2e/sdk-parity.ts
@@ -1,0 +1,478 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import type { IncomingHttpHeaders, OutgoingHttpHeaders } from 'node:http';
+import { after, before, describe, it } from 'node:test';
+// oxlint-disable-next-line no-restricted-imports -- Verify packaged public entrypoint.
+import { Perplexity as Candidate } from '@perplexity-ai/perplexity_ai';
+import { Perplexity as Published } from 'published-sdk';
+
+type Operation = (...args: unknown[]) => unknown;
+
+interface SdkClient {
+  async: { chat: { completions: { create: Operation; get: Operation; list: Operation } } };
+  browser: { sessions: { create: Operation; delete: Operation } };
+  chat: { completions: { create: Operation } };
+  contextualizedEmbeddings: { create: Operation };
+  embeddings: { create: Operation };
+  responses: {
+    cancel: Operation;
+    create: Operation;
+    files: { content: Operation; list: Operation };
+    retrieve: Operation;
+  };
+  search: { create: Operation };
+}
+
+interface MockResponse {
+  body: string;
+  headers: OutgoingHttpHeaders;
+  status: number;
+}
+
+interface CapturedRequest {
+  body: string;
+  headers: IncomingHttpHeaders;
+  method: string | undefined;
+  url: string | undefined;
+}
+
+interface TestCase {
+  expectedOutput?: unknown;
+  expectedRequest: {
+    authorization: string;
+    body: unknown;
+    method: string;
+    path: string;
+  };
+  invoke: (client: SdkClient) => unknown;
+  name: string;
+  response: MockResponse;
+}
+
+type ClientConstructor = new (options: { apiKey: string; baseURL: string; maxRetries: number }) => unknown;
+
+const jsonHeaders = { 'content-type': 'application/json' };
+const chatResponse = {
+  choices: [
+    {
+      finish_reason: 'stop',
+      index: 0,
+      message: { content: 'pong', role: 'assistant' },
+    },
+  ],
+  created: 1,
+  id: 'chatcmpl_test',
+  model: 'sonar',
+  usage: { completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 },
+};
+const responsesResponse = {
+  created_at: 1,
+  id: 'resp_test',
+  model: 'sonar',
+  object: 'response',
+  output: [
+    {
+      content: [{ annotations: [], text: 'pong', type: 'output_text' }],
+      id: 'msg_test',
+      role: 'assistant',
+      status: 'completed',
+      type: 'message',
+    },
+  ],
+  status: 'completed',
+};
+const asyncResponse = {
+  created_at: 1,
+  id: 'async_test',
+  model: 'sonar',
+  status: 'COMPLETED',
+};
+const responseStreamEvent = {
+  content_index: 0,
+  delta: 'pong',
+  item_id: 'msg_test',
+  output_index: 0,
+  sequence_number: 1,
+  type: 'response.output_text.delta',
+};
+
+function jsonResponse(body: unknown, status = 200): MockResponse {
+  return { body: JSON.stringify(body), headers: jsonHeaders, status };
+}
+
+function sseResponse(events: unknown[]): MockResponse {
+  return {
+    body: `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join('')}data: [DONE]\n\n`,
+    headers: { 'content-type': 'text/event-stream' },
+    status: 200,
+  };
+}
+
+function normalizeRequest(request: CapturedRequest) {
+  assert.ok(request.url);
+  const url = new URL(request.url, 'http://localhost');
+  url.searchParams.sort();
+
+  return {
+    authorization: request.headers.authorization,
+    body: request.body === '' ? undefined : JSON.parse(request.body),
+    method: request.method,
+    path: `${url.pathname}${url.search}`,
+  };
+}
+
+async function collect(stream: AsyncIterable<unknown>) {
+  const chunks: unknown[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+let pendingResponse: MockResponse | undefined;
+let capturedRequest: CapturedRequest | undefined;
+const server = createServer((request, response) => {
+  const chunks: Buffer[] = [];
+  request.on('data', (chunk) => chunks.push(chunk));
+  request.on('end', () => {
+    capturedRequest = {
+      body: Buffer.concat(chunks).toString(),
+      headers: request.headers,
+      method: request.method,
+      url: request.url,
+    };
+
+    assert.ok(pendingResponse);
+    response.writeHead(pendingResponse.status, pendingResponse.headers);
+    response.end(pendingResponse.body);
+  });
+});
+
+let baseURL: string;
+
+const cases: TestCase[] = [
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: {
+        messages: [{ content: 'ping', role: 'user' }],
+        model: 'sonar',
+      },
+      method: 'POST',
+      path: '/chat/completions',
+    },
+    invoke: (client) =>
+      client.chat.completions.create({
+        messages: [{ content: 'ping', role: 'user' }],
+        model: 'sonar',
+      }),
+    name: 'chat completion',
+    response: jsonResponse(chatResponse),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: {
+        messages: [{ content: 'ping', role: 'user' }],
+        model: 'sonar',
+        stream: true,
+      },
+      method: 'POST',
+      path: '/chat/completions',
+    },
+    invoke: async (client) =>
+      collect(
+        (await client.chat.completions.create({
+          messages: [{ content: 'ping', role: 'user' }],
+          model: 'sonar',
+          stream: true,
+        })) as AsyncIterable<unknown>,
+      ),
+    name: 'streaming chat completion',
+    response: sseResponse([chatResponse]),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: { max_results: 1, query: 'Perplexity SDK' },
+      method: 'POST',
+      path: '/search',
+    },
+    invoke: (client) => client.search.create({ max_results: 1, query: 'Perplexity SDK' }),
+    name: 'search',
+    response: jsonResponse({
+      id: 'search_test',
+      results: [{ snippet: 'SDK result', title: 'Perplexity', url: 'https://perplexity.ai' }],
+    }),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: { dimensions: 128, input: 'ping', model: 'pplx-embed-v1-0.6b' },
+      method: 'POST',
+      path: '/v1/embeddings',
+    },
+    invoke: (client) =>
+      client.embeddings.create({
+        dimensions: 128,
+        input: 'ping',
+        model: 'pplx-embed-v1-0.6b',
+      }),
+    name: 'embeddings',
+    response: jsonResponse({
+      data: [{ embedding: 'AA==', index: 0, object: 'embedding' }],
+      model: 'pplx-embed-v1-0.6b',
+      object: 'list',
+      usage: { prompt_tokens: 1, total_tokens: 1 },
+    }),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: {
+        dimensions: 128,
+        input: [['first chunk', 'second chunk']],
+        model: 'pplx-embed-context-v1-0.6b',
+      },
+      method: 'POST',
+      path: '/v1/contextualizedembeddings',
+    },
+    invoke: (client) =>
+      client.contextualizedEmbeddings.create({
+        dimensions: 128,
+        input: [['first chunk', 'second chunk']],
+        model: 'pplx-embed-context-v1-0.6b',
+      }),
+    name: 'contextualized embeddings',
+    response: jsonResponse({
+      data: [
+        {
+          data: [
+            { embedding: 'AA==', index: 0, object: 'embedding' },
+            { embedding: 'AQ==', index: 1, object: 'embedding' },
+          ],
+          index: 0,
+          object: 'contextualized_embedding',
+        },
+      ],
+      model: 'pplx-embed-context-v1-0.6b',
+      object: 'list',
+      usage: { prompt_tokens: 2, total_tokens: 2 },
+    }),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: { input: 'ping', model: 'sonar' },
+      method: 'POST',
+      path: '/v1/responses',
+    },
+    expectedOutput: { ...responsesResponse, output_text: 'pong' },
+    invoke: (client) => client.responses.create({ input: 'ping', model: 'sonar' }),
+    name: 'response creation',
+    response: jsonResponse(responsesResponse),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: { input: 'ping', model: 'sonar', stream: true },
+      method: 'POST',
+      path: '/v1/responses',
+    },
+    invoke: async (client) =>
+      collect(
+        (await client.responses.create({
+          input: 'ping',
+          model: 'sonar',
+          stream: true,
+        })) as AsyncIterable<unknown>,
+      ),
+    name: 'streaming response creation',
+    response: sseResponse([responseStreamEvent]),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: undefined,
+      method: 'GET',
+      path: '/v1/responses/resp_test',
+    },
+    expectedOutput: responsesResponse,
+    invoke: (client) => client.responses.retrieve('resp_test'),
+    name: 'response retrieval',
+    response: jsonResponse(responsesResponse),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: undefined,
+      method: 'POST',
+      path: '/v1/responses/resp_test/cancel',
+    },
+    invoke: (client) => client.responses.cancel('resp_test'),
+    name: 'response cancellation',
+    response: jsonResponse({ response_id: 'resp_test', status: 'cancelling' }),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: undefined,
+      method: 'GET',
+      path: '/v1/responses/resp_test/files',
+    },
+    invoke: (client) => client.responses.files.list('resp_test'),
+    name: 'response file listing',
+    response: jsonResponse({
+      data: [{ file_id: 'file_test', filename: 'result.txt', size_bytes: 4 }],
+      object: 'list',
+    }),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: undefined,
+      method: 'GET',
+      path: '/v1/responses/resp_test/files/file_test/content',
+    },
+    invoke: async (client) => {
+      const response = (await client.responses.files.content('file_test', {
+        response_id: 'resp_test',
+      })) as Response;
+      return {
+        contentDisposition: response.headers.get('content-disposition'),
+        text: await response.text(),
+      };
+    },
+    name: 'response file content',
+    response: {
+      body: 'pong',
+      headers: {
+        'content-disposition': 'attachment; filename="result.txt"',
+        'content-type': 'application/octet-stream',
+      },
+      status: 200,
+    },
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: {},
+      method: 'POST',
+      path: '/v1/browser/sessions',
+    },
+    invoke: (client) => client.browser.sessions.create({}),
+    name: 'browser session creation',
+    response: jsonResponse({ session_id: 'session_test', status: 'running' }),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: undefined,
+      method: 'DELETE',
+      path: '/v1/browser/sessions/session_test',
+    },
+    invoke: (client) => client.browser.sessions.delete('session_test'),
+    name: 'browser session deletion',
+    response: { body: '', headers: {}, status: 204 },
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: {
+        idempotency_key: 'key_test',
+        request: {
+          messages: [{ content: 'ping', role: 'user' }],
+          model: 'sonar',
+        },
+      },
+      method: 'POST',
+      path: '/async/chat/completions',
+    },
+    invoke: (client) =>
+      client.async.chat.completions.create({
+        idempotency_key: 'key_test',
+        request: {
+          messages: [{ content: 'ping', role: 'user' }],
+          model: 'sonar',
+        },
+      }),
+    name: 'async chat completion creation',
+    response: jsonResponse(asyncResponse),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: undefined,
+      method: 'GET',
+      path: '/async/chat/completions',
+    },
+    invoke: (client) => client.async.chat.completions.list(),
+    name: 'async chat completion listing',
+    response: jsonResponse({ requests: [asyncResponse] }),
+  },
+  {
+    expectedRequest: {
+      authorization: 'Bearer parity-token',
+      body: undefined,
+      method: 'GET',
+      path: '/async/chat/completions/async_test?local_mode=true',
+    },
+    invoke: (client) => client.async.chat.completions.get('async_test', { local_mode: true }),
+    name: 'async chat completion retrieval',
+    response: jsonResponse(asyncResponse),
+  },
+];
+
+const clients: Array<[string, ClientConstructor]> = [
+  ['candidate', Candidate],
+  ['published', Published],
+];
+
+describe('published SDK parity', { concurrency: false }, () => {
+  before(async () => {
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    assert.ok(typeof address !== 'string' && address !== null);
+    baseURL = `http://127.0.0.1:${address.port}`;
+  });
+
+  after(
+    () =>
+      new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+  );
+
+  for (const testCase of cases) {
+    it(testCase.name, async () => {
+      const results: Array<{ output: unknown; request: ReturnType<typeof normalizeRequest> }> = [];
+      for (const [sdkName, Client] of clients) {
+        pendingResponse = testCase.response;
+        capturedRequest = undefined;
+        const client = new Client({
+          apiKey: 'parity-token',
+          baseURL,
+          maxRetries: 0,
+        }) as SdkClient;
+        const output = await testCase.invoke(client);
+        assert.ok(capturedRequest, `${sdkName} sent no request`);
+        results.push({ output, request: normalizeRequest(capturedRequest) });
+      }
+
+      const candidate = results[0];
+      const published = results[1];
+      assert.ok(candidate);
+      assert.ok(published);
+      assert.deepStrictEqual(candidate.request, testCase.expectedRequest, 'candidate request changed');
+      assert.deepStrictEqual(published.request, testCase.expectedRequest, 'published request changed');
+      assert.deepStrictEqual(
+        candidate.output,
+        testCase.expectedOutput ?? published.output,
+        'candidate output changed',
+      );
+      assert.deepStrictEqual(
+        published.output,
+        testCase.expectedOutput ?? candidate.output,
+        'published output changed',
+      );
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "oxfmt": "^0.60.0",
     "oxlint": "^1.75.0",
     "publint": "^0.3.22",
+    "published-sdk": "npm:@perplexity-ai/perplexity_ai@0.37.0",
     "typescript": "7.0.2"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       publint:
         specifier: ^0.3.22
         version: 0.3.22
+      published-sdk:
+        specifier: npm:@perplexity-ai/perplexity_ai@0.37.0
+        version: '@perplexity-ai/perplexity_ai@0.37.0'
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -399,6 +402,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@perplexity-ai/perplexity_ai@0.37.0':
+    resolution: {integrity: sha512-SAHwhMdrIhn25tq1PbSOpyr0QYz2Bp9jn/xZ87xPmEEVpXwEyTiuUCT1S5crIBbiHSVUAZR8MwiNNmeMhkwKDw==}
 
   '@publint/pack@0.1.6':
     resolution: {integrity: sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA==}
@@ -1275,6 +1281,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.75.0':
     optional: true
+
+  '@perplexity-ai/perplexity_ai@0.37.0': {}
 
   '@publint/pack@0.1.6':
     dependencies:


### PR DESCRIPTION
Generated SDK now owns public API behavior, but runtime regressions can still pass unit tests while diverging from latest npm release.

- compares candidate package with npm `latest` across all 16 public operations
- validates request paths and bodies, JSON parsing, SSE streams, binary responses, async APIs, browser sessions, embeddings, search, chat, and responses
- keeps published SDK as test-only npm alias
- runs typed `node:test` suites directly with Node 26 strip-types
- adds runnable TypeScript examples for every documented API resource
- typechecks examples as API conformance fixtures
- runs mock parity in dedicated PR-safe workflow
- runs 9 live workflow parity tests in separate functional workflow with `PPLX_API_TOKEN`
- marks both Bazel targets `manual`, keeping non-hermetic tests out of `//...`
