### PR TITLE
chore: configure beta prereleases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
   "include-component-in-tag": false,
   "versioning": "prerelease",
   "prerelease": true,
+  "prerelease-type": "beta",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",


### PR DESCRIPTION
## Summary

- set Release Please prerelease type to `beta`
- keep upcoming `0.38.0` changes off npm's `latest` tag

## Why

Prerelease mode was enabled without a prerelease type, so Release Please still proposed stable `0.38.0`.

After merge, Release Please should update #60 to `0.38.0-beta`; npm publishing will use the `beta` dist-tag.

## Test

- parsed and asserted release configuration with Node.js
- `./node_modules/.bin/oxfmt --check release-please-config.json`
- pre-commit hooks
