### PR TITLE
refactor: consume generated TypeScript client bindings

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -19,41 +19,7 @@ import * as Errors from './core/error.js';
 import * as Uploads from './core/uploads.js';
 import { APIPromise } from './core/api-promise.js';
 import type { SdkTransport } from './generated/api.js';
-import * as API from './resources/index.js';
-import {
-  Annotation,
-  Async,
-  Browser,
-  Chat,
-  ContentPart,
-  ContextualizedEmbeddingCreateParams,
-  ContextualizedEmbeddingCreateResponse,
-  ContextualizedEmbeddings,
-  EmbeddingCreateParams,
-  EmbeddingCreateResponse,
-  Embeddings,
-  ErrorInfo,
-  FunctionCallOutputItem,
-  FunctionTool,
-  InputItem,
-  OutputItem,
-  ResponseCancelResponse,
-  ResponseCreateParams,
-  ResponseCreateResponse,
-  ResponseFile,
-  ResponseFileList,
-  ResponseRetrieveResponse,
-  ResponseStreamChunk,
-  Responses,
-  ResponsesCreateParams,
-  ResponsesUsage,
-  Search,
-  SearchCreateParams,
-  SearchCreateResponse,
-  StreamChunk,
-  ResponseCreateParamsNonStreaming,
-  ResponseCreateParamsStreaming,
-} from './resources/index.js';
+import { clientResourceClasses, createClientResources } from './resources/client.js';
 import { type Fetch } from './internal/builtin-types.js';
 import { HeadersLike, NullableHeaders, buildHeaders } from './internal/headers.js';
 import { FinalRequestOptions, RequestOptions } from './internal/request-options.js';
@@ -219,6 +185,7 @@ export class Perplexity implements SdkTransport {
     this._options = options;
 
     this.apiKey = apiKey;
+    Object.assign(this, createClientResources(this));
   }
 
   /**
@@ -771,85 +738,10 @@ export class Perplexity implements SdkTransport {
   static UnprocessableEntityError = Errors.UnprocessableEntityError;
 
   static toFile = Uploads.toFile;
-
-  chat = new Chat(this);
-  search = new Search(this);
-  responses = new Responses(this);
-  embeddings = new Embeddings(this);
-  contextualizedEmbeddings = new ContextualizedEmbeddings(this);
-  browser = new Browser(this);
-  async = new Async(this);
 }
 
-Perplexity.Chat = Chat;
-Perplexity.Search = Search;
-Perplexity.Responses = Responses;
-Perplexity.Embeddings = Embeddings;
-Perplexity.ContextualizedEmbeddings = ContextualizedEmbeddings;
-Perplexity.Browser = Browser;
-Perplexity.Async = Async;
+Object.assign(Perplexity, clientResourceClasses);
 
 export declare namespace Perplexity {
   export type RequestOptions = Opts.RequestOptions;
-
-  export { Chat as Chat, type StreamChunk as StreamChunk };
-
-  export {
-    Search as Search,
-    type SearchCreateResponse as SearchCreateResponse,
-    type SearchCreateParams as SearchCreateParams,
-  };
-
-  export {
-    Responses as Responses,
-    type Annotation as Annotation,
-    type ContentPart as ContentPart,
-    type ErrorInfo as ErrorInfo,
-    type FunctionCallOutputItem as FunctionCallOutputItem,
-    type FunctionTool as FunctionTool,
-    type InputItem as InputItem,
-    type OutputItem as OutputItem,
-    type ResponseFile as ResponseFile,
-    type ResponseFileList as ResponseFileList,
-    type ResponseStreamChunk as ResponseStreamChunk,
-    type ResponsesCreateParams as ResponsesCreateParams,
-    type ResponsesUsage as ResponsesUsage,
-    type ResponseCreateResponse as ResponseCreateResponse,
-    type ResponseRetrieveResponse as ResponseRetrieveResponse,
-    type ResponseCancelResponse as ResponseCancelResponse,
-    type ResponseCreateParams as ResponseCreateParams,
-    type ResponseCreateParamsNonStreaming as ResponseCreateParamsNonStreaming,
-    type ResponseCreateParamsStreaming as ResponseCreateParamsStreaming,
-  };
-
-  export {
-    Embeddings as Embeddings,
-    type EmbeddingCreateResponse as EmbeddingCreateResponse,
-    type EmbeddingCreateParams as EmbeddingCreateParams,
-  };
-
-  export {
-    ContextualizedEmbeddings as ContextualizedEmbeddings,
-    type ContextualizedEmbeddingCreateResponse as ContextualizedEmbeddingCreateResponse,
-    type ContextualizedEmbeddingCreateParams as ContextualizedEmbeddingCreateParams,
-  };
-
-  export { Browser as Browser };
-
-  export { Async as Async };
-
-  export type APIPublicSearchResult = API.APIPublicSearchResult;
-  export type BrowserSessionResponse = API.BrowserSessionResponse;
-  export type ChatMessageInput = API.ChatMessageInput;
-  export type ChatMessageOutput = API.ChatMessageOutput;
-  export type Choice = API.Choice;
-  export type ContextualizedEmbeddingObject = API.ContextualizedEmbeddingObject;
-  export type EmbeddingObject = API.EmbeddingObject;
-  export type EmbeddingsUsage = API.EmbeddingsUsage;
-  export type JsonSchemaFormat = API.JsonSchemaFormat;
-  export type ResponseFormat = API.ResponseFormat;
-  export type SearchResult = API.SearchResult;
-  export type UsageInfo = API.UsageInfo;
-  export type UserLocation = API.UserLocation;
-  export type WebSearchOptions = API.WebSearchOptions;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,6 +73,10 @@ describe('instantiate client', () => {
   });
 
   it('legacy resource entrypoints re-export generated resources', () => {
+    assert.strictEqual(Perplexity.Async, GeneratedAsync);
+    assert.strictEqual(Perplexity.Browser, GeneratedBrowser);
+    assert.strictEqual(Perplexity.Chat, GeneratedChat);
+    assert.strictEqual(Perplexity.Responses, GeneratedResponses);
     assert.deepStrictEqual(
       [
         LegacyAsync,

--- a/src/resources/BUILD.bazel
+++ b/src/resources/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
         "async.ts",
         "browser.ts",
         "chat.ts",
+        "client.ts",
         "contextualized-embeddings.ts",
         "embeddings.ts",
         "index.ts",

--- a/src/resources/client.ts
+++ b/src/resources/client.ts
@@ -1,0 +1,89 @@
+import * as API from '../generated/api.js';
+import type { SdkTransport } from '../generated/api.js';
+export interface ClientResources {
+    readonly async: API.Async;
+    readonly browser: API.Browser;
+    readonly chat: API.Chat;
+    readonly contextualizedEmbeddings: API.ContextualizedEmbeddings;
+    readonly embeddings: API.Embeddings;
+    readonly responses: API.Responses;
+    readonly search: API.Search;
+}
+export const clientResourceClasses = {
+    Async: API.Async,
+    Browser: API.Browser,
+    Chat: API.Chat,
+    ContextualizedEmbeddings: API.ContextualizedEmbeddings,
+    Embeddings: API.Embeddings,
+    Responses: API.Responses,
+    Search: API.Search
+};
+export function createClientResources(client: SdkTransport): ClientResources {
+    return {
+        async: new API.Async(client),
+        browser: new API.Browser(client),
+        chat: new API.Chat(client),
+        contextualizedEmbeddings: new API.ContextualizedEmbeddings(client),
+        embeddings: new API.Embeddings(client),
+        responses: new API.Responses(client),
+        search: new API.Search(client)
+    };
+}
+declare module '../client.js' {
+    interface Perplexity extends ClientResources {
+    }
+    namespace Perplexity {
+        export import Async = API.Async;
+        export import Browser = API.Browser;
+        export type SessionCreateParams = API.Browser.SessionCreateParams;
+        export import Chat = API.Chat;
+        export type CompletionCreateParams = API.Chat.CompletionCreateParams;
+        export type CompletionCreateParamsNonStreaming = API.Chat.CompletionCreateParamsNonStreaming;
+        export type CompletionCreateParamsStreaming = API.Chat.CompletionCreateParamsStreaming;
+        export type StreamChunk = API.Chat.StreamChunk;
+        export import ContextualizedEmbeddings = API.ContextualizedEmbeddings;
+        export type ContextualizedEmbeddingCreateParams = API.ContextualizedEmbeddings.ContextualizedEmbeddingCreateParams;
+        export type ContextualizedEmbeddingCreateResponse = API.ContextualizedEmbeddings.ContextualizedEmbeddingCreateResponse;
+        export import Embeddings = API.Embeddings;
+        export type EmbeddingCreateParams = API.Embeddings.EmbeddingCreateParams;
+        export type EmbeddingCreateResponse = API.Embeddings.EmbeddingCreateResponse;
+        export import Responses = API.Responses;
+        export type Annotation = API.Responses.Annotation;
+        export type ContentPart = API.Responses.ContentPart;
+        export type ErrorInfo = API.Responses.ErrorInfo;
+        export type FileContentParams = API.Responses.FileContentParams;
+        export type FunctionCallOutputItem = API.Responses.FunctionCallOutputItem;
+        export type FunctionTool = API.Responses.FunctionTool;
+        export type InputItem = API.Responses.InputItem;
+        export type OutputItem = API.Responses.OutputItem;
+        export type ResponseCancelResponse = API.Responses.ResponseCancelResponse;
+        export type ResponseCreateParams = API.Responses.ResponseCreateParams;
+        export type ResponseCreateParamsNonStreaming = API.Responses.ResponseCreateParamsNonStreaming;
+        export type ResponseCreateParamsStreaming = API.Responses.ResponseCreateParamsStreaming;
+        export type ResponseCreateResponse = API.Responses.ResponseCreateResponse;
+        export type ResponseFile = API.Responses.ResponseFile;
+        export type ResponseFileList = API.Responses.ResponseFileList;
+        export type ResponseRetrieveResponse = API.Responses.ResponseRetrieveResponse;
+        export type ResponsesCreateParams = API.Responses.ResponsesCreateParams;
+        export type ResponseStreamChunk = API.Responses.ResponseStreamChunk;
+        export type ResponsesUsage = API.Responses.ResponsesUsage;
+        export import Search = API.Search;
+        export type SearchCreateParams = API.Search.SearchCreateParams;
+        export type SearchCreateResponse = API.Search.SearchCreateResponse;
+        export type APIPublicSearchResult = API.APIPublicSearchResult;
+        export type BrowserSessionResponse = API.BrowserSessionResponse;
+        export type ChatMessageInput = API.ChatMessageInput;
+        export type ChatMessageOutput = API.ChatMessageOutput;
+        export type Choice = API.Choice;
+        export type ContextualizedEmbeddingObject = API.ContextualizedEmbeddingObject;
+        export type EmbeddingObject = API.EmbeddingObject;
+        export type EmbeddingsUsage = API.EmbeddingsUsage;
+        export type JsonSchemaFormat = API.JsonSchemaFormat;
+        export type ResponseFormat = API.ResponseFormat;
+        export type SearchResult = API.SearchResult;
+        export type UsageInfo = API.UsageInfo;
+        export type UserLocation = API.UserLocation;
+        export type WebSearchOptions = API.WebSearchOptions;
+    }
+}
+


### PR DESCRIPTION
## Why

`client.ts` manually repeats generated resource instances, static constructors, and namespace model aliases. API changes can leave this graph out of sync with generated resources.

## What

- consume generated client bindings from `src/resources/client.ts`
- keep transport, auth, retries, errors, and `RequestOptions` handwritten
- preserve existing instance, static, and namespace access paths
- verify generated static constructors at runtime

Generated by [ppl-ai/agi#179690](https://github.com/ppl-ai/agi/pull/179690).
