### PR TITLE
docs: add coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent guidance
+
+Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, development, and release
+commands.
+
+## Scope
+
+- Treat `src/generated/`, `src/resources.ts`, and `src/resources/` as output
+  from a private SDK codegen pipeline. Do not edit them.
+- Keep handwritten changes focused and preserve unrelated generated files.
+- Update `package.json` and `pnpm-lock.yaml` together for dependency changes.
+
+## Workflow
+
+- Use Bazel targets instead of direct Node test or build commands.
+- Run `bazel run //:gazelle` after adding files or changing imports.
+- Do not bump versions, edit release PR output, or publish packages manually.
+
+## Validation
+
+- Run `bazel test //...`.
+- Run `bazel test //:test //:package_checks //e2e:sdk_parity` for public-surface
+  changes.
+- Run `pnpm lefthook run pre-commit --all-files --force --fail-on-changes`.
+- Run live tests only when explicitly requested and `PPLX_API_TOKEN` is
+  available.


### PR DESCRIPTION
## What

Add a concise root `AGENTS.md` covering scope, private-generated files, Bazel/Gazelle workflow, release boundaries, and validation.

## Why

Coding agents need hard guardrails without duplicating `CONTRIBUTING.md`.

## Test

- Oxfmt
- `git diff --check`
- verified referenced files and targets against current `main`
