### PR TITLE
Add X-Pplx-Integration attribution header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -647,6 +647,7 @@ export class Perplexity implements SdkTransport {
       {
         Accept: 'application/json',
         'User-Agent': this.getUserAgent(),
+        'X-Pplx-Integration': 'perplexity-node/' + VERSION,
         'X-Source': 'perplexity-node',
         'X-Title': 'Perplexity Node SDK',
       },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,7 @@ import { Chat as LegacyChat } from './resources/chat/chat.js';
 import { Completions as LegacyChatCompletions } from './resources/chat/completions.js';
 import { Files as LegacyResponseFiles } from './resources/responses/files.js';
 import { Responses as LegacyResponses } from './resources/responses/responses.js';
+import { VERSION } from './version.js';
 const defaultFetch = fetch;
 
 describe('instantiate client', () => {
@@ -109,6 +110,16 @@ describe('instantiate client', () => {
     it('they are used in the request', async () => {
       const { req } = await client.buildRequest({ path: '/foo', method: 'post' });
       assert.deepStrictEqual(req.headers.get('x-my-default-header'), '2');
+      assert.deepStrictEqual(req.headers.get('x-pplx-integration'), `perplexity-node/${VERSION}`);
+    });
+
+    it('can override the integration attribution header', async () => {
+      const { req } = await client.buildRequest({
+        path: '/foo',
+        method: 'post',
+        headers: { 'X-Pplx-Integration': 'custom-integration/1.0.0' },
+      });
+      assert.deepStrictEqual(req.headers.get('x-pplx-integration'), 'custom-integration/1.0.0');
     });
 
     it('can ignore `undefined` and leave the default', async () => {


### PR DESCRIPTION
## Summary

Perplexity logs this opt-in header at API ingress for integration attribution. This adds the following default SDK header:

`X-Pplx-Integration: perplexity-node/<version>`

The value is well below the server-side 512-character cap. Caller-supplied headers retain precedence, and this introduces no behavior change beyond attribution metadata.

## Verification

- `bazel test //:test //:package_checks //e2e:sdk_parity` (5 of 6 targets passed; `//:attw` could not run `npm pack` in the local Bazel sandbox)
- `bazel build //:pkg`
- `pnpm lefthook run pre-commit --all-files --force --fail-on-changes`
