### PR TITLE
Add X-Pplx-Integration attribution header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -647,6 +647,7 @@ export class Perplexity implements SdkTransport {
       {
         Accept: 'application/json',
         'User-Agent': this.getUserAgent(),
+        'X-Pplx-Integration': 'perplexity-node/' + VERSION,
         'X-Source': 'perplexity-node',
         'X-Title': 'Perplexity Node SDK',
       },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,7 @@ import { Chat as LegacyChat } from './resources/chat/chat.js';
 import { Completions as LegacyChatCompletions } from './resources/chat/completions.js';
 import { Files as LegacyResponseFiles } from './resources/responses/files.js';
 import { Responses as LegacyResponses } from './resources/responses/responses.js';
+import { VERSION } from './version.js';
 const defaultFetch = fetch;
 
 describe('instantiate client', () => {
@@ -109,6 +110,16 @@ describe('instantiate client', () => {
     it('they are used in the request', async () => {
       const { req } = await client.buildRequest({ path: '/foo', method: 'post' });
       assert.deepStrictEqual(req.headers.get('x-my-default-header'), '2');
+      assert.deepStrictEqual(req.headers.get('x-pplx-integration'), `perplexity-node/${VERSION}`);
+    });
+
+    it('can override the integration attribution header', async () => {
+      const { req } = await client.buildRequest({
+        path: '/foo',
+        method: 'post',
+        headers: { 'X-Pplx-Integration': 'custom-integration/1.0.0' },
+      });
+      assert.deepStrictEqual(req.headers.get('x-pplx-integration'), 'custom-integration/1.0.0');
     });
 
     it('can ignore `undefined` and leave the default', async () => {


### PR DESCRIPTION
## Summary

Perplexity now records the opt-in `X-Pplx-Integration` header at API ingress. This adds `X-Pplx-Integration: perplexity-node/<version>` to the SDK's central default headers so every API resource is attributed consistently.

Caller-supplied headers retain precedence, and request behavior is otherwise unchanged.

## Verification

- The request-construction test observes `perplexity-node/<version>` on the final outbound request.
- The override test confirms callers can replace the default integration value.
- Preview and main comparison: n/a because this is a client SDK header change with no deployable preview surface.
